### PR TITLE
Add Android video chat app scaffold

### DIFF
--- a/android/VideoChatApp/README.md
+++ b/android/VideoChatApp/README.md
@@ -1,0 +1,34 @@
+# OmniCompose 视频聊天 App 骨架
+
+本目录提供一个从零起步的 Android Jetpack Compose 示例项目，覆盖“附近同城”“随机视频匹配”“一对一聊天入口”“个人资料”四个核心板块，并预留了 WebRTC 视频通话的引导代码，便于在现有仓库中快速落地移动端原型。
+
+## 目录结构
+- `build.gradle` / `settings.gradle`：顶层构建脚本。
+- `app/build.gradle`：应用模块依赖（Compose、Navigation、WebRTC、CameraX）。
+- `app/src/main/AndroidManifest.xml`：权限与入口 Activity 声明。
+- `app/src/main/java/com/example/omnicompose/`
+  - `ui/`：Jetpack Compose 界面、导航、ViewModel。
+  - `data/`：示例数据模型与假数据仓库。
+  - `call/VideoCallManager.kt`：WebRTC 初始化与本地音视频轨道示例。
+
+## 快速开始（在 Android Studio）
+1. 使用 Android Studio Giraffe+ 打开 `android/VideoChatApp` 目录。
+2. 确保本地安装 JDK 17；Gradle 插件 8.1.0、Kotlin 1.9.10 已在脚本中指定。
+3. 连接一台开启摄像头和麦克风的设备/模拟器，授予相机、录音、网络和定位权限。
+4. 运行应用，底部导航包含：
+   - 附近同城：展示示例用户列表并支持刷新城市数据。
+   - 随机视频：点击“开始速配”即可获取一位随机匹配的示例用户。
+   - 聊天：展示示例会话列表（可扩展为 IM + 视频拨号）。
+   - 我的：显示示例个人资料，包含“开启视频验证”按钮。
+
+## 对接真实后端与信令
+- 将 `UserRepository` 替换为实际的 REST/gRPC/GraphQL 数据源，填充附近和推荐列表。
+- 在 `MainViewModel.openChat/openProfile` 中对接聊天路由与用户详情页。
+- `VideoCallManager` 已封装 WebRTC 工厂、摄像头采集与本地轨道创建：
+  - 替换 `createPeerConnection` 调用处的 ICE 服务器列表（STUN/TURN）。
+  - 在 `SimplePeerObserver` 中将 SDP/ICE 事件通过 Socket.IO/MQTT 等推送到信令服务器。
+  - 在 UI 中使用 `org.webrtc.SurfaceViewRenderer` 或 Compose + `AndroidView` 嵌入远端/本地图像。
+
+## 注意事项
+- 示例使用 `https://placekitten.com` 作为头像占位图，请根据实际业务替换。
+- 生产环境需处理权限请求、网络异常、前后台生命周期、账号登录与风控、实时消息存储等。

--- a/android/VideoChatApp/app/build.gradle
+++ b/android/VideoChatApp/app/build.gradle
@@ -1,0 +1,46 @@
+apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
+
+android {
+    namespace "com.example.omnicompose"
+    compileSdkVersion 34
+
+    defaultConfig {
+        applicationId "com.example.omnicompose"
+        minSdkVersion 24
+        targetSdkVersion 34
+        versionCode 1
+        versionName "1.0"
+
+        vectorDrawables.useSupportLibrary = true
+    }
+
+    buildFeatures {
+        compose true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion "1.5.3"
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation platform("androidx.compose:compose-bom:2023.10.01")
+    implementation "androidx.compose.ui:ui"
+    implementation "androidx.compose.ui:ui-tooling-preview"
+    implementation "androidx.compose.material3:material3"
+    implementation "androidx.activity:activity-compose:1.8.0"
+    implementation "androidx.navigation:navigation-compose:2.7.6"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.2"
+
+    // Camera + WebRTC placeholder dependencies
+    implementation "org.webrtc:google-webrtc:1.0.32006"
+    implementation "androidx.camera:camera-camera2:1.3.0"
+    implementation "androidx.camera:camera-lifecycle:1.3.0"
+    implementation "androidx.camera:camera-view:1.3.0"
+}

--- a/android/VideoChatApp/app/src/main/AndroidManifest.xml
+++ b/android/VideoChatApp/app/src/main/AndroidManifest.xml
@@ -1,0 +1,26 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.omnicompose">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="Omni Compose"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.Material3.DayNight.NoActionBar">
+        <activity
+            android:name="com.example.omnicompose.ui.MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/android/VideoChatApp/app/src/main/java/com/example/omnicompose/call/VideoCallManager.kt
+++ b/android/VideoChatApp/app/src/main/java/com/example/omnicompose/call/VideoCallManager.kt
@@ -1,0 +1,102 @@
+package com.example.omnicompose.call
+
+import android.content.Context
+import org.webrtc.AudioSource
+import org.webrtc.AudioTrack
+import org.webrtc.Camera2Enumerator
+import org.webrtc.DefaultVideoDecoderFactory
+import org.webrtc.DefaultVideoEncoderFactory
+import org.webrtc.EglBase
+import org.webrtc.PeerConnection
+import org.webrtc.PeerConnectionFactory
+import org.webrtc.SurfaceTextureHelper
+import org.webrtc.VideoCapturer
+import org.webrtc.VideoSource
+import org.webrtc.VideoTrack
+
+/**
+ * Thin WebRTC bootstrap wrapper. Replace the TODO sections with your own
+ * signaling (Socket.IO/MQTT/etc.) and STUN/TURN credentials.
+ */
+class VideoCallManager(private val context: Context) {
+    private val eglBase = EglBase.create()
+    private var factory: PeerConnectionFactory? = null
+    private var localVideoSource: VideoSource? = null
+    private var audioSource: AudioSource? = null
+
+    fun initialize() {
+        val initOptions = PeerConnectionFactory.InitializationOptions.builder(context)
+            .setEnableInternalTracer(true)
+            .createInitializationOptions()
+        PeerConnectionFactory.initialize(initOptions)
+
+        val encoderFactory = DefaultVideoEncoderFactory(eglBase.eglBaseContext, true, true)
+        val decoderFactory = DefaultVideoDecoderFactory(eglBase.eglBaseContext)
+        factory = PeerConnectionFactory.builder()
+            .setVideoEncoderFactory(encoderFactory)
+            .setVideoDecoderFactory(decoderFactory)
+            .createPeerConnectionFactory()
+    }
+
+    fun startLocalTracks(): Pair<VideoTrack, AudioTrack> {
+        val pcFactory = factory ?: error("Call manager not initialized")
+        val videoCapturer = createCameraCapturer()
+        val surfaceHelper = SurfaceTextureHelper.create("CaptureThread", eglBase.eglBaseContext)
+        localVideoSource = pcFactory.createVideoSource(videoCapturer.isScreencast)
+        videoCapturer.initialize(surfaceHelper, context, localVideoSource!!.capturerObserver)
+        videoCapturer.startCapture(720, 1280, 30)
+        val videoTrack = pcFactory.createVideoTrack("LOCAL_VIDEO", localVideoSource)
+
+        audioSource = pcFactory.createAudioSource(MediaConstraintsBuilder.voice())
+        val audioTrack = pcFactory.createAudioTrack("LOCAL_AUDIO", audioSource)
+        return videoTrack to audioTrack
+    }
+
+    fun createPeerConnection(iceServers: List<PeerConnection.IceServer>): PeerConnection {
+        val pcFactory = factory ?: error("Call manager not initialized")
+        val rtcConfig = PeerConnection.RTCConfiguration(iceServers).apply {
+            sdpSemantics = PeerConnection.SdpSemantics.UNIFIED_PLAN
+        }
+        return pcFactory.createPeerConnection(rtcConfig, SimplePeerObserver())
+            ?: error("Failed to create peer connection")
+    }
+
+    fun release() {
+        localVideoSource?.dispose()
+        audioSource?.dispose()
+        factory?.dispose()
+        eglBase.release()
+    }
+
+    private fun createCameraCapturer(): VideoCapturer {
+        val enumerator = Camera2Enumerator(context)
+        val deviceName = enumerator.deviceNames.firstOrNull { enumerator.isFrontFacing(it) }
+            ?: enumerator.deviceNames.first()
+        return enumerator.createCapturer(deviceName, null)
+            ?: error("No camera capturer available")
+    }
+}
+
+object MediaConstraintsBuilder {
+    fun voice() = org.webrtc.MediaConstraints().apply {
+        mandatory.add(org.webrtc.MediaConstraints.KeyValuePair("OfferToReceiveAudio", "true"))
+        optional.add(org.webrtc.MediaConstraints.KeyValuePair("DtlsSrtpKeyAgreement", "true"))
+    }
+}
+
+class SimplePeerObserver : PeerConnection.Observer {
+    override fun onSignalingChange(p0: PeerConnection.SignalingState?) {}
+    override fun onIceConnectionChange(p0: PeerConnection.IceConnectionState?) {}
+    override fun onStandardizedIceConnectionChange(newState: PeerConnection.IceConnectionState?) {}
+    override fun onConnectionChange(newState: PeerConnection.PeerConnectionState?) {}
+    override fun onIceConnectionReceivingChange(p0: Boolean) {}
+    override fun onIceGatheringChange(p0: PeerConnection.IceGatheringState?) {}
+    override fun onIceCandidate(p0: org.webrtc.IceCandidate?) {}
+    override fun onIceCandidatesRemoved(p0: Array<out org.webrtc.IceCandidate>?) {}
+    override fun onAddStream(p0: org.webrtc.MediaStream?) {}
+    override fun onRemoveStream(p0: org.webrtc.MediaStream?) {}
+    override fun onDataChannel(p0: org.webrtc.DataChannel?) {}
+    override fun onRenegotiationNeeded() {}
+    override fun onAddTrack(p0: org.webrtc.RtpReceiver?, p1: Array<out org.webrtc.MediaStream>?) {}
+    override fun onTrack(transceiver: org.webrtc.RtpTransceiver?) {}
+}

--- a/android/VideoChatApp/app/src/main/java/com/example/omnicompose/data/Models.kt
+++ b/android/VideoChatApp/app/src/main/java/com/example/omnicompose/data/Models.kt
@@ -1,0 +1,18 @@
+package com.example.omnicompose.data
+
+data class UserProfile(
+    val id: String,
+    val name: String,
+    val city: String,
+    val age: Int,
+    val avatarUrl: String,
+    val bio: String,
+    val interests: List<String>
+)
+
+data class CallSession(
+    val sessionId: String,
+    val callee: UserProfile,
+    val isIncoming: Boolean,
+    val token: String? = null
+)

--- a/android/VideoChatApp/app/src/main/java/com/example/omnicompose/data/UserRepository.kt
+++ b/android/VideoChatApp/app/src/main/java/com/example/omnicompose/data/UserRepository.kt
@@ -1,0 +1,52 @@
+package com.example.omnicompose.data
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class UserRepository {
+    private val cache = MutableStateFlow(sampleUsers())
+
+    fun users(): Flow<List<UserProfile>> = cache.asStateFlow()
+
+    suspend fun refreshNearby(city: String) {
+        delay(300) // simulate network call
+        cache.value = sampleUsers().map { it.copy(city = city) }
+    }
+
+    suspend fun getRandomMatch(): UserProfile {
+        delay(500)
+        return cache.value.shuffled().first()
+    }
+
+    private fun sampleUsers(): List<UserProfile> = listOf(
+        UserProfile(
+            id = "u1",
+            name = "西瓜",
+            city = "杭州",
+            age = 23,
+            avatarUrl = "https://placekitten.com/200/200",
+            bio = "喜欢唱歌旅行",
+            interests = listOf("唱歌", "旅行", "撸猫")
+        ),
+        UserProfile(
+            id = "u2",
+            name = "大海",
+            city = "上海",
+            age = 26,
+            avatarUrl = "https://placekitten.com/201/201",
+            bio = "摄影师 & 咖啡控",
+            interests = listOf("摄影", "咖啡", "骑行")
+        ),
+        UserProfile(
+            id = "u3",
+            name = "小七",
+            city = "广州",
+            age = 25,
+            avatarUrl = "https://placekitten.com/202/202",
+            bio = "想找个聊得来的你",
+            interests = listOf("二次元", "手作", "电影")
+        )
+    )
+}

--- a/android/VideoChatApp/app/src/main/java/com/example/omnicompose/ui/MainActivity.kt
+++ b/android/VideoChatApp/app/src/main/java/com/example/omnicompose/ui/MainActivity.kt
@@ -1,0 +1,93 @@
+package com.example.omnicompose.ui
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Chat
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Videocam
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import com.example.omnicompose.data.UserRepository
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val repository = UserRepository()
+        setContent {
+            val navController = rememberNavController()
+            val vm: MainViewModel = viewModel(factory = MainViewModel.Factory(repository))
+
+            Scaffold(
+                bottomBar = { BottomBar(navController) }
+            ) { padding ->
+                NavHost(
+                    navController = navController,
+                    startDestination = Screen.Nearby.route,
+                    modifier = Modifier.padding(padding)
+                ) {
+                    composable(Screen.Nearby.route) {
+                        NearbyScreen(vm)
+                    }
+                    composable(Screen.Random.route) {
+                        RandomMatchScreen(vm)
+                    }
+                    composable(Screen.Chat.route) {
+                        ChatLobbyScreen(vm)
+                    }
+                    composable(Screen.Profile.route) {
+                        ProfileScreen(vm)
+                    }
+                }
+            }
+        }
+    }
+}
+
+sealed class Screen(val route: String, val title: String, val icon: androidx.compose.ui.graphics.vector.ImageVector) {
+    object Nearby : Screen("nearby", "附近", Icons.Default.LocationOn)
+    object Random : Screen("random", "速配", Icons.Default.Videocam)
+    object Chat : Screen("chat", "聊天", Icons.Default.Chat)
+    object Profile : Screen("profile", "我的", Icons.Default.Person)
+}
+
+@Composable
+fun BottomBar(navController: androidx.navigation.NavHostController) {
+    val items = listOf(Screen.Nearby, Screen.Random, Screen.Chat, Screen.Profile)
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentDestination = navBackStackEntry?.destination
+    NavigationBar {
+        items.forEach { screen ->
+            val selected = currentDestination?.route == screen.route
+            NavigationBarItem(
+                selected = selected,
+                onClick = {
+                    navController.navigate(screen.route) {
+                        popUpTo(navController.graph.findStartDestination().id) {
+                            saveState = true
+                        }
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                },
+                icon = { Icon(screen.icon, contentDescription = screen.title) },
+                label = { Text(screen.title) }
+            )
+        }
+    }
+}

--- a/android/VideoChatApp/app/src/main/java/com/example/omnicompose/ui/MainViewModel.kt
+++ b/android/VideoChatApp/app/src/main/java/com/example/omnicompose/ui/MainViewModel.kt
@@ -1,0 +1,64 @@
+package com.example.omnicompose.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.omnicompose.data.CallSession
+import com.example.omnicompose.data.UserProfile
+import com.example.omnicompose.data.UserRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class MainViewModel(private val repository: UserRepository) : ViewModel() {
+    private val _users = MutableStateFlow<List<UserProfile>>(emptyList())
+    val users: StateFlow<List<UserProfile>> = _users.asStateFlow()
+
+    private val _randomMatch = MutableStateFlow<UserProfile?>(null)
+    val randomMatch: StateFlow<UserProfile?> = _randomMatch.asStateFlow()
+
+    private val _mockConversations = MutableStateFlow<List<CallSession>>(emptyList())
+    val mockConversations: StateFlow<List<CallSession>> = _mockConversations.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            repository.users().collect { profiles ->
+                _users.value = profiles
+                _mockConversations.value = profiles.take(2).mapIndexed { index, profile ->
+                    CallSession(sessionId = "s$index", callee = profile, isIncoming = index % 2 == 0)
+                }
+            }
+        }
+    }
+
+    fun refreshNearby(city: String) {
+        viewModelScope.launch { repository.refreshNearby(city) }
+    }
+
+    fun findRandom() {
+        viewModelScope.launch { _randomMatch.value = repository.getRandomMatch() }
+    }
+
+    fun startVerification() {
+        // Hook up to your backend: upload selfie/video, request verification session, etc.
+    }
+
+    fun openProfile(profile: UserProfile) {
+        // Navigate to detail screen or open bottom sheet with profile detail.
+    }
+
+    fun openChat(profile: UserProfile) {
+        // Route to chat UI with messaging + call controls.
+    }
+
+    class Factory(private val repository: UserRepository) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(MainViewModel::class.java)) {
+                @Suppress("UNCHECKED_CAST")
+                return MainViewModel(repository) as T
+            }
+            throw IllegalArgumentException("Unknown ViewModel")
+        }
+    }
+}

--- a/android/VideoChatApp/app/src/main/java/com/example/omnicompose/ui/Screens.kt
+++ b/android/VideoChatApp/app/src/main/java/com/example/omnicompose/ui/Screens.kt
@@ -1,0 +1,147 @@
+package com.example.omnicompose.ui
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import com.example.omnicompose.data.UserProfile
+
+@Composable
+fun NearbyScreen(vm: MainViewModel) {
+    val users by vm.users.collectAsState(emptyList())
+    LaunchedEffect(Unit) { vm.refreshNearby("杭州") }
+    UserList(
+        title = "附近同城",
+        users = users,
+        onClick = { vm.openProfile(it) }
+    )
+}
+
+@Composable
+fun RandomMatchScreen(vm: MainViewModel) {
+    val match by vm.randomMatch.collectAsState()
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text("速配匹配", style = MaterialTheme.typography.titleLarge)
+        match?.let {
+            ProfileCard(it)
+        }
+        Button(onClick = { vm.findRandom() }) {
+            Text("开始速配")
+        }
+    }
+}
+
+@Composable
+fun ChatLobbyScreen(vm: MainViewModel) {
+    val sessions by vm.mockConversations.collectAsState(emptyList())
+    UserList(title = "聊天列表", users = sessions.map { it.callee }) { vm.openChat(it) }
+}
+
+@Composable
+fun ProfileScreen(vm: MainViewModel) {
+    val user = vm.users.collectAsState(emptyList()).value.firstOrNull()
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        user?.let { ProfileCard(it) }
+        Button(onClick = { vm.startVerification() }) { Text("开启视频验证") }
+    }
+}
+
+@Composable
+private fun UserList(title: String, users: List<UserProfile>, onClick: (UserProfile) -> Unit) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        Text(title, style = MaterialTheme.typography.titleLarge, modifier = Modifier.padding(16.dp))
+        LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            items(users) { user ->
+                ProfileRow(user, onClick)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProfileRow(user: UserProfile, onClick: (UserProfile) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick(user) }
+            .padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Image(
+            painter = rememberAsyncImagePainter(user.avatarUrl),
+            contentDescription = null,
+            modifier = Modifier.size(64.dp).clip(CircleShape).background(Color.LightGray),
+            contentScale = ContentScale.Crop
+        )
+        Column(modifier = Modifier.padding(start = 12.dp)) {
+            Text(user.name, fontWeight = FontWeight.Bold)
+            Text("${user.age} · ${user.city}")
+            Text(user.bio, maxLines = 1, style = MaterialTheme.typography.bodySmall)
+        }
+    }
+}
+
+@Composable
+private fun ProfileCard(user: UserProfile) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+    ) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Image(
+                    painter = rememberAsyncImagePainter(user.avatarUrl),
+                    contentDescription = null,
+                    modifier = Modifier.size(72.dp).clip(CircleShape).background(Color.LightGray),
+                    contentScale = ContentScale.Crop
+                )
+                Column(modifier = Modifier.padding(start = 12.dp)) {
+                    Text(user.name, style = MaterialTheme.typography.titleMedium)
+                    Text("${user.age}岁 · ${user.city}")
+                }
+            }
+            Text(user.bio)
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                user.interests.forEach {
+                    Text(text = it, modifier = Modifier.background(Color.DarkGray.copy(alpha = 0.1f)).padding(6.dp))
+                }
+            }
+        }
+    }
+    Spacer(modifier = Modifier.height(8.dp))
+}

--- a/android/VideoChatApp/app/src/main/res/values/strings.xml
+++ b/android/VideoChatApp/app/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<resources>
+    <string name="app_name">Omni Compose</string>
+    <string name="nearby">附近同城</string>
+    <string name="random">随机视频</string>
+    <string name="chat">聊天</string>
+    <string name="profile">我的</string>
+</resources>

--- a/android/VideoChatApp/app/src/main/res/values/themes.xml
+++ b/android/VideoChatApp/app/src/main/res/values/themes.xml
@@ -1,0 +1,3 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.Material3.DayNight.NoActionBar" parent="Theme.Material3.DayNight.NoActionBar" />
+</resources>

--- a/android/VideoChatApp/build.gradle
+++ b/android/VideoChatApp/build.gradle
@@ -1,0 +1,22 @@
+// Top-level Gradle build file
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:8.1.0"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
+}

--- a/android/VideoChatApp/settings.gradle
+++ b/android/VideoChatApp/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "OmniComposeVideoChat"
+include(":app")


### PR DESCRIPTION
## Summary
- add Jetpack Compose Android sample project with nearby, random match, chat, and profile tabs
- include WebRTC bootstrap helper and placeholder data repository for matching flows
- document setup steps and backend integration notes in the new module README

## Testing
- not run (Android project scaffolding only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923ca2790288325b5c2af4da48bfc40)